### PR TITLE
Fix: Insure at least 2d output from `MetricModel.encode`

### DIFF
--- a/quaterion_models/model.py
+++ b/quaterion_models/model.py
@@ -122,7 +122,12 @@ class MetricModel(nn.Module):
             all_embeddings = torch.cat(all_embeddings, dim=0)
 
         if not input_was_list:
-            all_embeddings = all_embeddings[0]
+            all_embeddings = all_embeddings.squeeze()
+
+        if to_numpy:
+            all_embeddings = np.atleast_2d(all_embeddings)
+        else:
+            all_embeddings = torch.atleast_2d(all_embeddings)
 
         return all_embeddings
 


### PR DESCRIPTION
Returning 0th element directly as previously brings strange behaviors, particularly with batched tensors as inputs. This fix insures that we always return at least 2d outputs, enabling it to play more nicely with different types of inputs.