### PR TITLE
allow default collate in encoders

### DIFF
--- a/quaterion_models/encoders/encoder.py
+++ b/quaterion_models/encoders/encoder.py
@@ -1,5 +1,6 @@
 from torch import Tensor
 from torch import nn
+from torch.utils.data.dataloader import default_collate
 
 from quaterion_models.types import TensorInterchange, CollateFnType
 
@@ -40,7 +41,7 @@ class Encoder(nn.Module):
 
         :return: Model input
         """
-        raise NotImplementedError()
+        return default_collate
 
     def forward(self, batch: TensorInterchange) -> Tensor:
         """


### PR DESCRIPTION
Default collate might be useful if user only uses single encoder with standard dataset like MNIST 