### PR TITLE
Add skip-dropout

### DIFF
--- a/quaterion_models/heads/skip_connection_head.py
+++ b/quaterion_models/heads/skip_connection_head.py
@@ -63,7 +63,10 @@ class SkipConnectionHead(EncoderHead):
         Returns:
             torch.Tensor: shape: (batch_size, input_embedding_size)
         """
-        return self.fc(self.skip_dropout(input_vectors)) * torch.sigmoid(self.gates) + input_vectors
+        return (
+            self.fc(self.skip_dropout(input_vectors)) * torch.sigmoid(self.gates)
+            + input_vectors
+        )
 
     def reset_parameters(self) -> None:
         torch.nn.init.constant_(


### PR DESCRIPTION
Discovered, that there is a difference in applying dropout to the whole output of encoders, of on the update-able component of the skip-connection head only. 
This difference may be significant for some application, so I decided to allow setting up this dropouts separately.

Here is some observations:
- If dropout is applied on both branches - the train performance may be compromised on the start of training - initially, the gates are all closed and the resulting embedding is same as outputs the pre-trained model, unless the dropout is applied. 
- Dropout is applied on the train loop only, validation performs better as there are no dropout during the `.eval`
- Configuring dropout to the small value `~0.1`, eventually allows the head layer to reconstruct valuable signal and compensate the effect of dropout. Larges values, however, still able to train, but under-fits on training phase 