### PR TITLE
Quick fix for `switch_collate_fn` used with single type of inputs

### DIFF
--- a/quaterion_models/encoders/switch_encoder.py
+++ b/quaterion_models/encoders/switch_encoder.py
@@ -78,7 +78,9 @@ class SwitchEncoder(Encoder):
             switch_ordering[record_encoder].append(original_id)
 
         switch_batches = {
-            key: encoder_collates[key](batch) for key, batch in switch_batches.items() if len(batch) > 0
+            key: encoder_collates[key](batch)
+            for key, batch in switch_batches.items()
+            if len(batch) > 0
         }
 
         return {"ordering": switch_ordering, "batches": switch_batches}

--- a/quaterion_models/encoders/switch_encoder.py
+++ b/quaterion_models/encoders/switch_encoder.py
@@ -78,7 +78,7 @@ class SwitchEncoder(Encoder):
             switch_ordering[record_encoder].append(original_id)
 
         switch_batches = {
-            key: encoder_collates[key](batch) for key, batch in switch_batches.items()
+            key: encoder_collates[key](batch) for key, batch in switch_batches.items() if len(batch) > 0
         }
 
         return {"ordering": switch_ordering, "batches": switch_batches}


### PR DESCRIPTION
When we use a single type of inputs in a batch during inference for example, e.g., only images, then the list created for other encoders, e.g., text encoder, will be empty and those encoders will be called with an empty list, causing unpredictable behavior.

This small fix insures that an encoder will be always called with an non-empty list.