### PR TITLE
Fix "list index out of range" for models with multiple encoders

### DIFF
--- a/quaterion_models/utils/meta.py
+++ b/quaterion_models/utils/meta.py
@@ -16,6 +16,6 @@ def merge_meta(meta: Dict[str, list]) -> List[dict]:
         if aggregated is None:
             aggregated = encoder_meta
         else:
-            for i in range(len(meta)):
+            for i in range(len(aggregated)):
                 aggregated[i].update(encoder_meta[i])
     return aggregated

--- a/tests/utils/test_meta.py
+++ b/tests/utils/test_meta.py
@@ -1,0 +1,15 @@
+from typing import Dict
+
+from quaterion_models.utils.meta import merge_meta
+
+
+def test_merge_meta():
+    input_test: Dict[str, list] = {
+        "encoder_a": [{"a": 1}, {"a": 2}],
+        "encoder_b": [{"b": 3}, {"b": 4}],
+        "encoder_c": [{"c": 5}, {"c": 6}],
+    }
+    expected = [{"a": 1, "b": 3, "c": 5}, {"a": 2, "b": 4, "c": 6}]
+    actual = merge_meta(input_test)
+
+    assert actual == expected


### PR DESCRIPTION
This PR fix a "list index out of range" issue when inferring from a Quaterion model with multiple encoders. 

This bug wasn't visible in the example provided as the number of metadata for each encoder was equal to the number of encoders.

Adding also a test to validate the change